### PR TITLE
chore(tests): use ^0.5.1 falcor-router rather than master

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "eslint": "^0.21.0",
-    "falcor-router": "git+ssh://git@github.com/Netflix/falcor-router.git",
+    "falcor-router": "^0.5.1",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.0.0",
     "gulp-mocha": "^2.1.3",


### PR DESCRIPTION
Using `falcor-router` master might make tests slightly more brittle as it will be using a version of falcor-router that might not be (or perhaps never will be) published. `falcor-router` master *should* be pretty stable. But it should affect tests on this repository.